### PR TITLE
WIP: extensibility draft

### DIFF
--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -2,7 +2,7 @@ import { BehaviorSubject } from "rxjs";
 import { coreProxy } from "./core/proxy";
 import { BehaviorSubjectProxy, Key, Path } from "./core/types";
 
-export function behaviorSubject<O>(source$: BehaviorSubject<O>, distinct?: boolean): BehaviorSubjectProxy<O> {
+export function behaviorSubject<O, X = {}>(source$: BehaviorSubject<O>, x?: X, distinct?: boolean): BehaviorSubjectProxy<O, X> {
   const rootGetter = () => source$.value;
 
   const setter = deepSetter(
@@ -22,7 +22,7 @@ export function behaviorSubject<O>(source$: BehaviorSubject<O>, distinct?: boole
     return overrides[p];
   };
 
-  return coreProxy(source$, [], getOverride, distinct) as BehaviorSubjectProxy<O>;
+  return coreProxy(source$, [], getOverride, x, distinct) as unknown as BehaviorSubjectProxy<O, X>;
 }
 
 // poor man's getter and setter

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -4,14 +4,14 @@ import { noop, OBSERVABLE_INSTANCE_PROP_KEYS } from "./shared";
 import { Key, ObservableProxy, Path } from "./types";
 
 // core api proxy
-export function coreProxy<O>(o: Observable<O>, ps: Path = [], getOverride?: (ps: Path, p: Key) => (() => any) | null, distinct?: boolean): ObservableProxy<O> {
+export function coreProxy<O, X>(o: Observable<O>, ps: Path = [], getOverride?: (ps: Path, p: Key) => (() => any) | null, x?: X, distinct?: boolean): ObservableProxy<O, X> {
   // we need to preserve property proxies, so that
   // ```ts
   // let o = of({ a: 42 });
   // let p = proxify(o);
   // assert(p.a === p.a);
   // ```
-  const proxyForPropertyCache = new Map<keyof O, ObservableProxy<O[keyof O]>>();
+  const proxyForPropertyCache = new Map<keyof O, ObservableProxy<O[keyof O], X>>();
 
   return (new Proxy(noop, {
     // call result = O.fn in Observable<O>
@@ -30,11 +30,21 @@ export function coreProxy<O>(o: Observable<O>, ps: Path = [], getOverride?: (ps:
             return f;
           })
         ),
+        void 0,
+        void 0,
+        x
       );
     },
 
     // get Observable<O.prop> from Observable<O>
     get(_, p: keyof O & keyof Observable<O>, receiver) {
+      if (x && p in x) {
+        const f = x[p as string];
+        if (typeof f == 'function') {
+          Reflect.apply(f, o.pipe(deepPluck(ps), maybeDistinct(distinct)), [])
+        }
+      }
+
       const override = getOverride && getOverride(ps, p);
       if (override) {
         return override();
@@ -56,7 +66,7 @@ export function coreProxy<O>(o: Observable<O>, ps: Path = [], getOverride?: (ps:
         // we should wrap piped observable into another proxy
         return function () {
           const applied = Reflect.apply(builtIn, deepO, arguments);
-          return coreProxy(applied);
+          return coreProxy(applied, void 0, void 0, x);
         };
       }
 
@@ -65,10 +75,11 @@ export function coreProxy<O>(o: Observable<O>, ps: Path = [], getOverride?: (ps:
       }
 
       // return proxified sub-property
-      const subproxy = coreProxy<O[typeof p]>(
+      const subproxy = coreProxy<O[typeof p], X>(
         o as any,
         ps.concat(p),
         getOverride,
+        x,
         distinct
       );
 
@@ -76,7 +87,7 @@ export function coreProxy<O>(o: Observable<O>, ps: Path = [], getOverride?: (ps:
       proxyForPropertyCache.set(p, subproxy);
       return subproxy;
     },
-  }) as unknown) as ObservableProxy<O>;
+  }) as unknown) as ObservableProxy<O, X>;
 }
 
 // Helper Operators

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -2,6 +2,6 @@ import { Observable } from "rxjs";
 import { coreProxy } from "./core/proxy";
 import { ObservableProxy } from "./core/types";
 
-export function observable<O>(source$: Observable<O>): ObservableProxy<O> {
-  return coreProxy(source$, []) as ObservableProxy<O>;
+export function observable<O, X>(source$: Observable<O>, x?: X): ObservableProxy<O, X> {
+  return coreProxy(source$, [], void 0, x) as ObservableProxy<O, X>;
 }

--- a/src/proxify.ts
+++ b/src/proxify.ts
@@ -5,20 +5,20 @@ import { observable } from "./observable";
 import { subject } from "./subject";
 
 export { BehaviorSubjectProxy, ObservableProxy, SubjectProxy };
-export function proxify<O>(source: BehaviorSubject<O>): BehaviorSubjectProxy<O>;
-export function proxify<O>(source: Subject<O>): SubjectProxy<O>;
-export function proxify<O>(source: Observable<O>): ObservableProxy<O>;
-export function proxify<O>(source: Observable<O>) {
+export function proxify<O, X = void>(source: BehaviorSubject<O>, x?: X): BehaviorSubjectProxy<O, X>;
+export function proxify<O, X = void>(source: Subject<O>, x?: X): SubjectProxy<O, X>;
+export function proxify<O, X = void>(source: Observable<O>, x?: X): ObservableProxy<O, X>;
+export function proxify<O, X = void>(source: Observable<O>, x?: X) {
   if (source instanceof BehaviorSubject) {
-    return behaviorSubject(source as BehaviorSubject<O>);
+    return behaviorSubject(source as BehaviorSubject<O>, x);
   }
 
   if (source instanceof Subject) {
-    return subject(source as Subject<O>);
+    return subject(source as Subject<O>, x);
   }
 
   if (isObservable(source)) {
-    return observable(source as Observable<O>);
+    return observable(source as Observable<O>, x);
   }
 
   throw 'Source should be Observable, Subject, or BehaviorSubject';

--- a/src/statify.ts
+++ b/src/statify.ts
@@ -2,8 +2,8 @@ import { BehaviorSubject } from "rxjs";
 import { behaviorSubject } from "./behavior";
 import { BehaviorSubjectProxy } from "./core/types";
 
-export function statify<T>(o: T): BehaviorSubjectProxy<T> {
-  return behaviorSubject(new BehaviorSubject(o), true);
+export function statify<T,X>(o: T, x?: X): BehaviorSubjectProxy<T, X> {
+  return behaviorSubject(new BehaviorSubject(o), x, true);
 }
 
 /**

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -2,7 +2,7 @@ import { Subject } from "rxjs";
 import { coreProxy } from "./core/proxy";
 import { Key, Path, SubjectProxy } from "./core/types";
 
-export function subject<O>(source$: Subject<O>): SubjectProxy<O> {
+export function subject<O, X>(source$: Subject<O>, x?: X): SubjectProxy<O, X> {
   // overrides work only for root values
   const overrides = {
     next: () => v => source$.next(v),
@@ -18,5 +18,5 @@ export function subject<O>(source$: Subject<O>): SubjectProxy<O> {
     return overrides[p];
   }
 
-  return coreProxy(source$, [], getOverride) as SubjectProxy<O>;
+  return coreProxy(source$, [], getOverride, x) as unknown as SubjectProxy<O, X>;
 }

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -1,0 +1,15 @@
+import { of } from "rxjs";
+import { ObservableProxy, proxify } from "../src";
+
+interface Extension {
+  _<S>(this:S): S extends ObservableProxy<infer A, unknown> ? A : never;
+  $<S>(this:S): S extends ObservableProxy<infer A, unknown> ? A : never;
+}
+
+const x: Extension = {
+  _() { return 1 as any; },
+  $() { return 1 as any; }
+}
+
+let source = proxify(of({ a: 1 }, { a: 2 }), x);
+const d = source.a._()

--- a/tests/observable.test.ts
+++ b/tests/observable.test.ts
@@ -128,7 +128,7 @@ describe('Proxify', () => {
     });
 
     it('should keep the THIS context', () => {
-      const a = function () {
+      const a = function (this: { b: number }) {
         return this.b;
       };
       const o = of({ a, b: 1 }, { a, b: 2 }, { a, b: 3 });
@@ -227,7 +227,7 @@ describe('Proxify', () => {
       it('should filter', () => {
         proxify(of([1, 2, 3]))
           .filter(x => x != 2)
-        [1]
+          [1]
           .subscribe(observer)
 
         expect(observer.next.mock.calls).toEqual([[3]]);


### PR DESCRIPTION
This allows adding functions on the proxy fields (fix #3)

E.g.:

```ts
interface Extension {
  readValue<S>(this:S): S extends ObservableProxy<infer A, unknown> ? A : never;
}

const x: Extension = {
  readValue() { return this… }
}

const source = proxify(of({ a: 1 }, { a: 2 }), x);
const d = source.a.readValue() // d: number
```

This might be handy if combined with [rxjs-autorun](https://github.com/kosich/rxjs-autorun):

```ts
// RxJS :: Autorun + Proxify 
const s = statify({ a: '🐰', b: '🏡' });
autorun(() => s.b.$() + s.a._()); //🏡🐰
s.b.next('🛸'); //🛸🐰
```

----

I don't quite like the typing output and code should be refactored to include this feature.
Also, it's not clear at what level should this extension be applied and when dropped (observable/subject/behaviorSubject)