### PR TITLE
WIP: Allow statify to be coerced to primitive

### DIFF
--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -13,6 +13,7 @@ export function behaviorSubject<O>(source$: BehaviorSubject<O>, distinct?: boole
     const overrides = {
       value: readValue,
       getValue: () => readValue,
+      [Symbol.toPrimitive]: () => readValue,
       next: () => value => {
         if (!distinct || value !== readValue()) {
           setter(ps, value);

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -13,7 +13,18 @@ export function behaviorSubject<O>(source$: BehaviorSubject<O>, distinct?: boole
     const overrides = {
       value: readValue,
       getValue: () => readValue,
-      [Symbol.toPrimitive]: () => readValue,
+      [Symbol.toPrimitive]: () => () => {
+        const prop = readValue();
+        if (prop instanceof Date) return prop.valueOf();
+        return prop;
+      },
+      [Symbol.iterator]: () => {
+        return function* () {
+          for (let i = 0; i < readValue().length; i++) {
+            yield coreProxy(source$, ps.concat(i), getOverride, distinct);
+          }
+        };
+      },
       next: () => value => {
         if (!distinct || value !== readValue()) {
           setter(ps, value);

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -25,6 +25,7 @@ export function behaviorSubject<O>(source$: BehaviorSubject<O>, distinct?: boole
           }
         };
       },
+      toJSON: () => readValue,
       next: () => value => {
         if (!distinct || value !== readValue()) {
           setter(ps, value);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -20,7 +20,7 @@ export type BehaviorSubjectProxy<O> =
     O extends (...args: infer P) => infer R
     ? ICallableProxiedObservable<O, P, R>
     : IProxiedState<O>
-  );
+  ) & O;
 
 // helper to distinguish root types
 type TProxy<O, K extends ProxyKind> =

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -109,5 +109,17 @@ describe('State', () => {
       const state = statify({ a: 2 });
       expect(JSON.stringify(state)).toBe('{"a":2}');
     });
+
+    it('Coerces when spread', () => {
+      const state = statify({ a: 2 });
+      const newState = { ...state, b: 3 };
+      expect(+newState.a).toBe(2);
+    });
+
+    it('Coerces when Object.assign', () => {
+      const state = statify({ a: 2 });
+      const newState = Object.assign({}, state, { b: 3 });
+      expect(+newState.a).toBe(2);
+    });
   });
 });

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -104,5 +104,10 @@ describe('State', () => {
       state = statify({ a: false });
       expect(+state.a).toBeFalsy();
     });
+
+    it('Coerces when JSON.stringify called', () => {
+      const state = statify({ a: 2 });
+      expect(JSON.stringify(state)).toBe('{"a":2}');
+    });
   });
 });

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -66,4 +66,33 @@ describe('State', () => {
       expect(observer.next).not.toHaveBeenCalled();
     });
   });
+
+  describe('Coercable statify', () => {
+    it('Coerces to a string', () => {
+      const state = statify({ hello: 'Hello, ' });
+      expect(state.hello + 'world!').toBe('Hello, world!');
+    });
+
+    it('Coerces to a number', () => {
+      const state = statify({ a: 10 });
+      expect(state.a + 2).toBe(12);
+    });
+
+    /**
+     * TODO: Figure out how to proxy [Symbol.iterator]
+     * Here's a clue: https://stackoverflow.com/questions/41046085/v8-es6-proxies-dont-support-iteration-protocol-when-targeting-custom-objects
+     *
+     * As well as proxying the symbol, we may have to manually
+     * proxy array props: 'length', '0', '1', ...
+     */
+    it.skip('Coerces to an array', () => {
+      const state = statify({ a: [1, 2, 3] });
+      expect([...state.a, 4]).toBe([1, 2, 3, 4]);
+    });
+
+    it.skip('Use elements of an array', () => {
+      const state = statify({ a: [1, 2, 3] });
+      expect(state.a[2]).toBe(3);
+    });
+  });
 });

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -78,21 +78,31 @@ describe('State', () => {
       expect(state.a + 2).toBe(12);
     });
 
-    /**
-     * TODO: Figure out how to proxy [Symbol.iterator]
-     * Here's a clue: https://stackoverflow.com/questions/41046085/v8-es6-proxies-dont-support-iteration-protocol-when-targeting-custom-objects
-     *
-     * As well as proxying the symbol, we may have to manually
-     * proxy array props: 'length', '0', '1', ...
-     */
-    it.skip('Coerces to an array', () => {
+    it('Coerces to an array', () => {
       const state = statify({ a: [1, 2, 3] });
-      expect([...state.a, 4]).toBe([1, 2, 3, 4]);
+
+      const newArr = [...state.a, 4];
+
+      expect(newArr).toStrictEqual([1, 2, 3, 4]);
     });
 
-    it.skip('Use elements of an array', () => {
+    it('Coerces elements of an array', () => {
       const state = statify({ a: [1, 2, 3] });
-      expect(state.a[2]).toBe(3);
+      expect(+state.a[2]).toBe(3);
+    });
+
+    it('Coerces a date to a number', () => {
+      const date = new Date();
+      const state = statify({ a: date });
+      const coercedDate = new Date(state.a);
+      expect(coercedDate.valueOf()).toBe(date.valueOf());
+    });
+
+    it('Coerces a boolean', () => {
+      let state = statify({ a: true });
+      expect(+state.a).toBeTruthy();
+      state = statify({ a: false });
+      expect(+state.a).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
You mentioned in the comments that it would be cool if `statify` allowed direct access to its `BehaviorSubject`'s value.

So far, this allows direct access to strings and numbers by coercion. Typescript allows this through intersection types.

I'm not quite sure how to proxy [Symbol.iterator] yet to allow for direct access to array properties, but I think it's possible. I added some notes in the test cases.